### PR TITLE
Use latest platform

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -8,3 +8,6 @@ BASHLOG_FILE_PATH=platform.log
 
 #Hapi FHIR
 FHIR_IG_URL="https://openhie.github.io/HIV-CBS"
+
+## To change version of fhir used. Default is R4
+#FHIR_VERSION=R5

--- a/.env.qa
+++ b/.env.qa
@@ -15,3 +15,6 @@ STAGING=false
 
 #Hapi FHIR
 FHIR_IG_URL="https://openhie.github.io/HIV-CBS"
+
+## To change version of fhir used. Default is R4
+#FHIR_VERSION=R5

--- a/README.md
+++ b/README.md
@@ -30,3 +30,7 @@ The `./depoy-{environment}.sh` scripts will default to using the `Linux` binary 
 1. The `./deploy-local.sh` and `./replace-ig-local.sh` scripts will make use of Platform profiles which are specified to configure the services for local development purposes exposing the ports of these services and allowing access to the Hapi-FHIR GUI.
 ### QA:
 1. The `./deploy-qa.sh` and `./replace-ig-qa.sh` scripts will make use of Platform profiles which are specified to configure the services for QA purposes, securing the services and disallowing access to the Hapi-FHIR GUI.
+
+## Deploying specific version of fhir
+
+To deploy a specific version of FHIR, use the environment variable FHIR_VERSION. Default value is R4

--- a/config.yml
+++ b/config.yml
@@ -1,6 +1,6 @@
 ---
 projectName: FHIR-training-on-platform
-image: jembi/platform:2.4.0
+image: jembi/platform:2.4.3
 logPath: /tmp/logs
 
 packages:
@@ -61,5 +61,3 @@ profiles:
       - ./.env.qa
     dev: false
     only: true
-
-# hapi-fhir-cli upload-terminology -d "/Users/joeflack4/projects/hapi-fhir-jpaserver-starter/data/custom1/custom1.zip" -v r4 -t http://20.119.216.32:8080/fhir -u http://20.119.216.32:8080/fhir/CodeSystem/2


### PR DESCRIPTION
Make use of the latest platform image in which the version of fhir used is configurable through an environment variable - FHIR_VERSION. default value is R4