### PR TITLE
Refactor Hapi FHIR IG replacement script to prevent volume removal

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -9,5 +9,7 @@ BASHLOG_FILE_PATH=platform.log
 #Hapi FHIR
 FHIR_IG_URL="https://openhie.github.io/HIV-CBS"
 
+IMPORT_ONLY=""
+
 ## To change version of fhir used. Default is R4
 #FHIR_VERSION=R5

--- a/.env.qa
+++ b/.env.qa
@@ -16,5 +16,7 @@ STAGING=false
 #Hapi FHIR
 FHIR_IG_URL="https://openhie.github.io/HIV-CBS"
 
+IMPORT_ONLY=""
+
 ## To change version of fhir used. Default is R4
 #FHIR_VERSION=R5

--- a/replace-ig-local.sh
+++ b/replace-ig-local.sh
@@ -11,20 +11,17 @@ fi
 case ${operating_system} in
 linux)
   echo "Running with the Linux CLI binary"
-  ./instant-linux package down --profile=local-remove-fhir
-  ./instant-linux package up --profile=local-deploy-ig
+  ./instant-linux package up --profile=local-deploy-ig --env-var=IMPORT_ONLY=hapi-fhir
   exit 0
   ;;
 macos)
   echo "Running with the MacOS CLI binary"
-  ./instant-macos package down --profile=local-remove-fhir
-  ./instant-macos package up --profile=local-deploy-ig
+  ./instant-macos package up --profile=local-deploy-ig --env-var=IMPORT_ONLY=hapi-fhir
   exit 0
   ;;
 windows)
   echo "Running with the Windows CLI binary"
-  ./instant.exe package down --profile=local-remove-fhir
-  ./instant.exe package up --profile=local-deploy-ig
+  ./instant.exe package up --profile=local-deploy-ig --env-var=IMPORT_ONLY=hapi-fhir
   exit 0
   ;;
 --help)

--- a/replace-ig-local.sh
+++ b/replace-ig-local.sh
@@ -11,20 +11,20 @@ fi
 case ${operating_system} in
 linux)
   echo "Running with the Linux CLI binary"
-  ./instant-linux package remove --profile=local-remove-fhir
-  ./instant-linux package init --profile=local-deploy-ig
+  ./instant-linux package down --profile=local-remove-fhir
+  ./instant-linux package up --profile=local-deploy-ig
   exit 0
   ;;
 macos)
   echo "Running with the MacOS CLI binary"
-  ./instant-macos package remove --profile=local-remove-fhir
-  ./instant-macos package init --profile=local-deploy-ig
+  ./instant-macos package down --profile=local-remove-fhir
+  ./instant-macos package up --profile=local-deploy-ig
   exit 0
   ;;
 windows)
   echo "Running with the Windows CLI binary"
-  ./instant.exe package remove --profile=local-remove-fhir
-  ./instant.exe package init --profile=local-deploy-ig
+  ./instant.exe package down --profile=local-remove-fhir
+  ./instant.exe package up --profile=local-deploy-ig
   exit 0
   ;;
 --help)

--- a/replace-ig-qa.sh
+++ b/replace-ig-qa.sh
@@ -11,20 +11,17 @@ fi
 case ${operating_system} in
 linux)
   echo "Running with the Linux CLI binary"
-  ./instant-linux package down --profile=qa-remove-fhir
-  ./instant-linux package up --profile=qa-deploy-ig
+  ./instant-linux package up --profile=qa-deploy-ig --env-var=IMPORT_ONLY=hapi-fhir
   exit 0
   ;;
 macos)
   echo "Running with the MacOS CLI binary"
-  ./instant-macos package down --profile=qa-remove-fhir
-  ./instant-macos package up --profile=qa-deploy-ig
+  ./instant-macos package up --profile=qa-deploy-ig --env-var=IMPORT_ONLY=hapi-fhir
   exit 0
   ;;
 windows)
   echo "Running with the Windows CLI binary"
-  ./instant.exe package down --profile=qa-remove-fhir
-  ./instant.exe package up --profile=qa-deploy-ig
+  ./instant.exe package up --profile=qa-deploy-ig --env-var=IMPORT_ONLY=hapi-fhir
   exit 0
   ;;
 --help)

--- a/replace-ig-qa.sh
+++ b/replace-ig-qa.sh
@@ -11,20 +11,20 @@ fi
 case ${operating_system} in
 linux)
   echo "Running with the Linux CLI binary"
-  ./instant-linux package remove --profile=qa-remove-fhir
-  ./instant-linux package init --profile=qa-deploy-ig
+  ./instant-linux package down --profile=qa-remove-fhir
+  ./instant-linux package up --profile=qa-deploy-ig
   exit 0
   ;;
 macos)
   echo "Running with the MacOS CLI binary"
-  ./instant-macos package remove --profile=qa-remove-fhir
-  ./instant-macos package init --profile=qa-deploy-ig
+  ./instant-macos package down --profile=qa-remove-fhir
+  ./instant-macos package up --profile=qa-deploy-ig
   exit 0
   ;;
 windows)
   echo "Running with the Windows CLI binary"
-  ./instant.exe package remove --profile=qa-remove-fhir
-  ./instant.exe package init --profile=qa-deploy-ig
+  ./instant.exe package down --profile=qa-remove-fhir
+  ./instant.exe package up --profile=qa-deploy-ig
   exit 0
   ;;
 --help)

--- a/swarm.sh
+++ b/swarm.sh
@@ -50,6 +50,11 @@ function deploy_importers() {
   for service_path in "${COMPOSE_FILE_PATH}/importer/"*/; do
     target_service_name=$(basename "$service_path")
 
+    if [[ $IMPORT_ONLY != "" && "${target_service_name}" != $IMPORT_ONLY ]]; then
+      log warn "IMPORT_ONLY ($IMPORT_ONLY) doesnt match $target_service_name. continue..."
+      continue
+    fi
+
     # Only run the importer for fhir datastore when validation is enabled
     if [[ $DISABLE_VALIDATION == "true" ]] && [[ "${target_service_name}" == "hapi-fhir" ]]; then
       log warn "Validation is disabled... Skipping the deploy of hapi fhir config importer"


### PR DESCRIPTION
Changed the commands in the replace-ig-*.sh files from "remove" and "init" to "down" and "up" to preserve the container volumes when the .sh file is run.